### PR TITLE
Criação do hook useForm

### DIFF
--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+/*
+ * Hook para inputs controlados
+ * função que usa do spread operator para copiar os valores atuais do form
+ * e substituirá os inputs que tiverem as propriedades name, e value por
+ * valores dinâmicos, e finalizo atualizando o estado do form com esses valores
+ *
+ * e aproveitando o código para criar um reset nos inputs para seus estados iniciais
+ */
+const useForm = (initialState) => {
+  const [form, setForm] = useState(initialState);
+
+  const onChangeInput = (name, value) => {
+    const newForm = { ...form, [name]: value };
+
+    setForm(newForm);
+  };
+
+  const resetState = () => {
+    setForm(initialState);
+  };
+
+  return [form, onChangeInput, resetState];
+};
+export default useForm;


### PR DESCRIPTION
Apenas criei dentro da pasta hooks o hook useForm para controlar os estados dos inputs.

A lógica da função é usar o spread operator, para substituir o estado atual de cada input por estados dinâmicos, e aproveitei o código para criar um reset voltando os inputs para um estado inicial.